### PR TITLE
Align header navigation to the right

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -72,7 +72,7 @@ const Header = () => {
                 />
               </Link>
             </div>
-            <div className="flex w-full items-center justify-between px-4">
+            <div className="ml-auto flex items-center justify-end px-4">
               <div>
                 <button
                   onClick={navbarToggleHandler}


### PR DESCRIPTION
## Summary
- move nav links to the right side of the header so the logo has more room

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bc0fbb1a088333b01780cf86cac476