### PR TITLE
fix: eliminate header flicker on first load

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,9 @@
-"use client";
-
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import ScrollToTop from "@/components/ScrollToTop";
 import { Inter } from "next/font/google";
 import "../styles/index.css";
+import { Providers } from "./providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -33,5 +32,4 @@ export default function RootLayout({
   );
 }
 
-import { Providers } from "./providers";
 

--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 
 export default function ScrollToTop() {


### PR DESCRIPTION
## Summary
- render root layout on the server so global styles load before paint
- mark ScrollToTop as a client component now that layout is server-rendered

## Testing
- `npm run lint`
- `npm run build` *(fails: `next/font` could not download Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68bc161472e4833382860d417d64a59f