### PR TITLE
feat: improve hero branding and quote CTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "postcss": "^8.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "tailwindcss": "^4.1.3"
+        "tailwindcss": "^4.1.3",
+        "typewriter-effect": "^2.22.0"
       },
       "devDependencies": {
         "@types/node": "^20.8.9",
@@ -4566,6 +4567,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4771,6 +4778,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -5560,6 +5576,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typewriter-effect": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/typewriter-effect/-/typewriter-effect-2.22.0.tgz",
+      "integrity": "sha512-01HCRYY462wT8Fxps/epwGCioZd/GMXY0aLKhFKrfJ5Xhgf54/SiDx7Oq7PoES5kGqOEAdW8FS8HYVM2WSvfhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "raf": "^3.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "postcss": "^8.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.3"
+    "tailwindcss": "^4.1.3",
+    "typewriter-effect": "^2.22.0"
   },
   "devDependencies": {
     "@types/node": "^20.8.9",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -56,7 +56,13 @@ const Header = () => {
         <div className="container">
           <div className="relative -mx-4 flex items-center justify-between">
             <div className="w-60 max-w-full px-4 xl:mr-12">
-              <Link href="/" className="header-logo block w-full py-5 lg:py-2">
+              <Link
+                href="/"
+                className="header-logo flex w-full items-center space-x-2 py-5 lg:py-2"
+              >
+                <span className="text-xl font-bold text-black dark:text-white">
+                  Rayan Trading
+                </span>
                 <Image
                   src="/images/logo/logo-2.svg"
                   alt="logo"

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
+import Typewriter from "typewriter-effect";
 
 const Hero = () => {
   return (
@@ -13,34 +16,52 @@ const Hero = () => {
         src="/images/lexus.jpg" // Put your image in public/images/
         alt="Hero Background"
         fill
-        className="absolute inset-0 object-cover opacity-70 dark:opacity-30"
-        style={{ objectFit: 'cover', filter: 'brightness(0.5)' }}
+        className="absolute inset-0 object-cover"
+        style={{ objectFit: 'cover' }}
         priority
       />
+      <div className="absolute inset-0 bg-black/60" />
 
         <div className="container relative">
           <div className="-mx-4 flex flex-wrap">
             <div className="w-full px-4">
-              <div className="mx-auto max-w-[800px] text-center">
-                <h1 className="mb-5 text-3xl font-bold leading-tight text-black dark:text-white sm:text-4xl sm:leading-tight md:text-5xl md:leading-tight">
-                  Your gateway to Japan&apos;s best vehicles
+              <div className="mx-auto max-w-[800px] text-center text-white">
+                <div className="mb-8 flex items-center justify-center space-x-3">
+                  <span className="text-4xl font-extrabold">Rayan Trading</span>
+                  <Image
+                    src="/images/logo/logo-2.svg"
+                    alt="Rayan Trading logo"
+                    width={80}
+                    height={40}
+                    className="dark:hidden"
+                  />
+                  <Image
+                    src="/images/logo/logo.svg"
+                    alt="Rayan Trading logo"
+                    width={80}
+                    height={40}
+                    className="hidden dark:block"
+                  />
+                </div>
+                <h1 className="mb-5 text-3xl font-bold leading-tight sm:text-4xl sm:leading-tight md:text-5xl md:leading-tight">
+                  <Typewriter
+                    options={{
+                      strings: ["Your gateway to Japan's best vehicles"],
+                      autoStart: true,
+                      loop: false,
+                    }}
+                  />
                 </h1>
-                <p className="mb-12 text-base leading-relaxed! text-body-color dark:text-body-color-dark sm:text-lg md:text-xl">
+                <p className="mb-8 text-base leading-relaxed sm:text-lg md:text-xl">
                   Whether it’s Japanese cars, commercial trucks, heavy machinery like forklifts and excavators, or non-Japanese vehicles — we’re your trusted partner for sourcing and shipping quality vehicles worldwide, hassle-free
                 </p>
-                <div className="flex flex-col items-center justify-center space-y-4 sm:flex-row sm:space-x-4 sm:space-y-0">
+                <div className="flex items-center justify-center">
                   <Link
                     href="/signin"
                     className="rounded-xs bg-primary px-8 py-4 text-base font-semibold text-white duration-300 ease-in-out hover:bg-primary/80"
                   >
                     Get a Free Quote
                   </Link>
-                  {/* <Link
-                    href="https://github.com/NextJSTemplates/startup-nextjs"
-                    className="inline-block rounded-xs bg-black px-8 py-4 text-base font-semibold text-white duration-300 ease-in-out hover:bg-black/90 dark:bg-white/10 dark:text-white dark:hover:bg-white/5"
-                  >
-                    Star on GitHub
-                  </Link> */}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add dark overlay, company name, and animated headline on landing hero
- show "Rayan Trading" before the logo in the site header
- include typewriter-effect dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68bc39cc2a3083339623145feb6a2db5